### PR TITLE
add wezterm colorschemes

### DIFF
--- a/.wezterm/colors/carbonfox.toml
+++ b/.wezterm/colors/carbonfox.toml
@@ -1,0 +1,69 @@
+
+[metadata]
+name = "carbonfox"
+author = "EdenEast"
+origin_url = "https://github.com/EdenEast/nightfox.nvim"
+
+[colors]
+foreground = "#f2f4f8"
+background = "#161616"
+cursor_bg = "#f2f4f8"
+cursor_border = "#f2f4f8"
+cursor_fg = "#161616"
+compose_cursor = '#3ddbd9'
+selection_bg = "#2a2a2a"
+selection_fg = "#f2f4f8"
+scrollbar_thumb = "#7b7c7e"
+split = "#0c0c0c"
+visual_bell = "#f2f4f8"
+ansi = ["#282828", "#ee5396", "#25be6a", "#08bdba", "#78a9ff", "#be95ff", "#33b1ff", "#dfdfe0"]
+brights = ["#484848", "#f16da6", "#46c880", "#2dc7c4", "#8cb6ff", "#c8a5ff", "#52bdff", "#e4e4e5"]
+
+[colors.indexed]
+16 = "#ff7eb6"
+17 = "#3ddbd9"
+
+[colors.tab_bar]
+background = "#0c0c0c"
+inactive_tab_edge = "#0c0c0c"
+inactive_tab_edge_hover = "#252525"
+
+[colors.tab_bar.active_tab]
+bg_color = "#7b7c7e"
+fg_color = "#161616"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#252525"
+fg_color = "#b6b8bb"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#353535"
+fg_color = "#f2f4f8"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab]
+bg_color = "#161616"
+fg_color = "#b6b8bb"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#353535"
+fg_color = "#f2f4f8"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"

--- a/.wezterm/colors/dawnfox.toml
+++ b/.wezterm/colors/dawnfox.toml
@@ -1,0 +1,69 @@
+[metadata]
+name = "dawnfox"
+author = "EdenEast"
+origin_url = "https://github.com/EdenEast/nightfox.nvim"
+
+[colors]
+foreground = "#575279"
+background = "#faf4ed"
+cursor_bg = "#575279"
+cursor_border = "#575279"
+cursor_fg = "#faf4ed"
+compose_cursor = '#d7827e'
+selection_bg = "#d0d8d8"
+selection_fg = "#575279"
+scrollbar_thumb = "#a8a3b3"
+split = "#ebe5df"
+visual_bell = "#575279"
+ansi = ["#575279", "#b4637a", "#618774", "#ea9d34", "#286983", "#907aa9", "#56949f", "#e5e9f0"]
+brights = ["#5f5695", "#c26d85", "#629f81", "#eea846", "#2d81a3", "#9a80b9", "#5ca7b4", "#e6ebf3"]
+
+[colors.indexed]
+16 = "#d685af"
+17 = "#d7827e"
+
+[colors.tab_bar]
+background = "#ebe5df"
+inactive_tab_edge = "#ebe5df"
+inactive_tab_edge_hover = "#ebe0df"
+
+[colors.tab_bar.active_tab]
+bg_color = "#a8a3b3"
+fg_color = "#faf4ed"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#ebe0df"
+fg_color = "#625c87"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#ebdfe4"
+fg_color = "#575279"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab]
+bg_color = "#faf4ed"
+fg_color = "#625c87"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#ebdfe4"
+fg_color = "#575279"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+

--- a/.wezterm/colors/dayfox.toml
+++ b/.wezterm/colors/dayfox.toml
@@ -1,0 +1,69 @@
+[metadata]
+name = "dayfox"
+author = "EdenEast"
+origin_url = "https://github.com/EdenEast/nightfox.nvim"
+
+[colors]
+foreground = "#1d344f"
+background = "#eaeaea"
+cursor_bg = "#1d344f"
+cursor_border = "#1d344f"
+cursor_fg = "#eaeaea"
+compose_cursor = '#e3786c'
+selection_bg = "#ced5de"
+selection_fg = "#1d344f"
+scrollbar_thumb = "#2e537d"
+split = "#dbdbdb"
+visual_bell = "#1d344f"
+ansi = ["#1d344f", "#b95d76", "#618774", "#ba793e", "#4d688e", "#8e6f98", "#6ca7bd", "#cdd1d5"]
+brights = ["#24476f", "#c76882", "#629f81", "#ca884a", "#4e75aa", "#9f75ac", "#74b2c9", "#cfd6dd"]
+
+[colors.indexed]
+16 = "#d685af"
+17 = "#e3786c"
+
+[colors.tab_bar]
+background = "#dbdbdb"
+inactive_tab_edge = "#dbdbdb"
+inactive_tab_edge_hover = "#dbcece"
+
+[colors.tab_bar.active_tab]
+bg_color = "#2e537d"
+fg_color = "#eaeaea"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#dbcece"
+fg_color = "#233f5e"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#ced6db"
+fg_color = "#1d344f"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab]
+bg_color = "#eaeaea"
+fg_color = "#233f5e"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#ced6db"
+fg_color = "#1d344f"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+

--- a/.wezterm/colors/duskfox.toml
+++ b/.wezterm/colors/duskfox.toml
@@ -1,0 +1,68 @@
+[metadata]
+name = "duskfox"
+author = "EdenEast"
+origin_url = "https://github.com/EdenEast/nightfox.nvim"
+
+[colors]
+foreground = "#e0def4"
+background = "#232136"
+cursor_bg = "#e0def4"
+cursor_border = "#e0def4"
+cursor_fg = "#232136"
+compose_cursor = '#ea9a97'
+selection_bg = "#433c59"
+selection_fg = "#e0def4"
+scrollbar_thumb = "#6e6a86"
+split = "#191726"
+visual_bell = "#e0def4"
+ansi = ["#393552", "#eb6f92", "#a3be8c", "#f6c177", "#569fba", "#c4a7e7", "#9ccfd8", "#e0def4"]
+brights = ["#47407d", "#f083a2", "#b1d196", "#f9cb8c", "#65b1cd", "#ccb1ed", "#a6dae3", "#e2e0f7"]
+
+[colors.indexed]
+16 = "#eb98c3"
+17 = "#ea9a97"
+
+[colors.tab_bar]
+background = "#191726"
+inactive_tab_edge = "#191726"
+inactive_tab_edge_hover = "#2d2a45"
+
+[colors.tab_bar.active_tab]
+bg_color = "#6e6a86"
+fg_color = "#232136"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#2d2a45"
+fg_color = "#cdcbe0"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#373354"
+fg_color = "#e0def4"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab]
+bg_color = "#232136"
+fg_color = "#cdcbe0"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#373354"
+fg_color = "#e0def4"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"

--- a/.wezterm/colors/nightfox.toml
+++ b/.wezterm/colors/nightfox.toml
@@ -1,0 +1,68 @@
+[metadata]
+name = "nightfox"
+author = "EdenEast"
+origin_url = "https://github.com/EdenEast/nightfox.nvim"
+
+[colors]
+foreground = "#cdcecf"
+background = "#192330"
+cursor_bg = "#cdcecf"
+cursor_border = "#cdcecf"
+cursor_fg = "#192330"
+compose_cursor = '#f4a261'
+selection_bg = "#2b3b51"
+selection_fg = "#cdcecf"
+scrollbar_thumb = "#71839b"
+split = "#131a24"
+visual_bell = "#cdcecf"
+ansi = ["#393b44", "#c94f6d", "#81b29a", "#dbc074", "#719cd6", "#9d79d6", "#63cdcf", "#dfdfe0"]
+brights = ["#575860", "#d16983", "#8ebaa4", "#e0c989", "#86abdc", "#baa1e2", "#7ad4d6", "#e4e4e5"]
+
+[colors.indexed]
+16 = "#d67ad2"
+17 = "#f4a261"
+
+[colors.tab_bar]
+background = "#131a24"
+inactive_tab_edge = "#131a24"
+inactive_tab_edge_hover = "#212e3f"
+
+[colors.tab_bar.active_tab]
+bg_color = "#71839b"
+fg_color = "#192330"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#212e3f"
+fg_color = "#aeafb0"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#29394f"
+fg_color = "#cdcecf"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab]
+bg_color = "#192330"
+fg_color = "#aeafb0"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#29394f"
+fg_color = "#cdcecf"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"

--- a/.wezterm/colors/nordfox.toml
+++ b/.wezterm/colors/nordfox.toml
@@ -1,0 +1,68 @@
+[metadata]
+name = "nordfox"
+author = "EdenEast"
+origin_url = "https://github.com/EdenEast/nightfox.nvim"
+
+[colors]
+foreground = "#cdcecf"
+background = "#2e3440"
+cursor_bg = "#cdcecf"
+cursor_border = "#cdcecf"
+cursor_fg = "#2e3440"
+compose_cursor = '#c9826b'
+selection_bg = "#3e4a5b"
+selection_fg = "#cdcecf"
+scrollbar_thumb = "#7e8188"
+split = "#232831"
+visual_bell = "#cdcecf"
+ansi = ["#3b4252", "#bf616a", "#a3be8c", "#ebcb8b", "#81a1c1", "#b48ead", "#88c0d0", "#e5e9f0"]
+brights = ["#465780", "#d06f79", "#b1d196", "#f0d399", "#8cafd2", "#c895bf", "#93ccdc", "#e7ecf4"]
+
+[colors.indexed]
+16 = "#bf88bc"
+17 = "#c9826b"
+
+[colors.tab_bar]
+background = "#232831"
+inactive_tab_edge = "#232831"
+inactive_tab_edge_hover = "#39404f"
+
+[colors.tab_bar.active_tab]
+bg_color = "#7e8188"
+fg_color = "#2e3440"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#39404f"
+fg_color = "#abb1bb"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#444c5e"
+fg_color = "#cdcecf"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab]
+bg_color = "#2e3440"
+fg_color = "#abb1bb"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#444c5e"
+fg_color = "#cdcecf"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"

--- a/.wezterm/colors/terafox.toml
+++ b/.wezterm/colors/terafox.toml
@@ -1,0 +1,68 @@
+[metadata]
+name = "terafox"
+author = "EdenEast"
+origin_url = "https://github.com/EdenEast/nightfox.nvim"
+
+[colors]
+foreground = "#e6eaea"
+background = "#152528"
+cursor_bg = "#e6eaea"
+cursor_border = "#e6eaea"
+cursor_fg = "#152528"
+compose_cursor = '#ff8349'
+selection_bg = "#293e40"
+selection_fg = "#e6eaea"
+scrollbar_thumb = "#587b7b"
+split = "#0f1c1e"
+visual_bell = "#e6eaea"
+ansi = ["#2f3239", "#e85c51", "#7aa4a1", "#fda47f", "#5a93aa", "#ad5c7c", "#a1cdd8", "#ebebeb"]
+brights = ["#4e5157", "#eb746b", "#8eb2af", "#fdb292", "#73a3b7", "#b97490", "#afd4de", "#eeeeee"]
+
+[colors.indexed]
+16 = "#cb7985"
+17 = "#ff8349"
+
+[colors.tab_bar]
+background = "#0f1c1e"
+inactive_tab_edge = "#0f1c1e"
+inactive_tab_edge_hover = "#1d3337"
+
+[colors.tab_bar.active_tab]
+bg_color = "#587b7b"
+fg_color = "#152528"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#1d3337"
+fg_color = "#cbd9d8"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#254147"
+fg_color = "#e6eaea"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab]
+bg_color = "#152528"
+fg_color = "#cbd9d8"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#254147"
+fg_color = "#e6eaea"
+intensity = "Normal"
+italic = false
+strikethrough = false
+underline = "None"

--- a/.wezterm/wezterm.lua
+++ b/.wezterm/wezterm.lua
@@ -1,6 +1,6 @@
 local wezterm = require("wezterm")
 
-local color_scheme = "Afterglow"
+local color_scheme = "duskfox"
 local font = "Cica"
 
 return {


### PR DESCRIPTION
- add wezterm colorschemes supported by EdenEast/nightfox.nvim
- change wezterm colorscheme: Afterglow to duskfox
